### PR TITLE
switch to new vbrowser fork

### DIFF
--- a/dev/dockerbox.sh
+++ b/dev/dockerbox.sh
@@ -6,9 +6,7 @@ apt-get install -y curl
 # install docker
 curl -fsSL https://get.docker.com | sh
 # pull vbrowser image
-docker pull howardc93/vbrowser
-# install fonts
-apt-get install -y fonts-noto-cjk
+docker pull howardc93/vbrowser2
 # install certbot
 DEBIAN_FRONTEND=noninteractive apt-get install -y certbot
 certbot certonly --standalone -n --email howardzchung@gmail.com --agree-tos -d docker1.watchparty.me

--- a/dev/vbrowser.sh
+++ b/dev/vbrowser.sh
@@ -6,14 +6,12 @@ apt-get install -y curl
 # install docker
 curl -fsSL https://get.docker.com | sh
 # pull vbrowser image
-docker pull howardc93/vbrowser
-# install fonts
-apt-get install -y fonts-noto-cjk
-# install dnsutils
+docker pull howardc93/vbrowser2
+# install dnsutils (iptables?)
 apt-get install -y dnsutils
 # disable unattended-upgrades
 apt-get remove -y unattended-upgrades
-# disable ipv6 on reboot
+# disable ipv6 on reboot (fixes region detection sometimes)
 echo '[Unit]
 Description=Disable IPV6
 
@@ -25,4 +23,4 @@ ExecStart=/bin/sh -c "sysctl -w net.ipv6.conf.all.disable_ipv6=1 && sysctl -w ne
 WantedBy=multi-user.target' > /etc/systemd/system/ipv6.service
 systemctl enable ipv6.service
 
-docker run -d --rm --name=test --log-opt max-size=1g --net=host --shm-size=1g --cap-add="SYS_ADMIN" -e DISPLAY=":99.0" -e NEKO_SCREEN="1920x1080@30" -e NEKO_PASSWORD=neko -e NEKO_PASSWORD_ADMIN=admin -e NEKO_BIND=":5000" -e NEKO_EPR=":59000-59100" howardc93/vbrowser
+docker run -d --rm --name=test --log-opt max-size=1g --net=host --shm-size=1g --cap-add="SYS_ADMIN" -e DISPLAY=":99.0" -e NEKO_SCREEN="1920x1080@30" -e NEKO_PASSWORD=neko -e NEKO_PASSWORD_ADMIN=admin -e NEKO_BIND=":5000" -e NEKO_EPR=":59000-59100" howardc93/vbrowser2

--- a/server/ecosystem.config.js
+++ b/server/ecosystem.config.js
@@ -45,7 +45,7 @@ module.exports = {
         HETZNER_GATEWAY_US: 'gateway2.watchparty.me',
         HETZNER_NETWORKS_US: '1258313,1258314,1258315',
         HETZNER_SSH_KEYS: '1570536',
-        HETZNER_IMAGE: '61352611',
+        HETZNER_IMAGE: '61619048',
         SCW_GATEWAY: 'gateway1.watchparty.me',
         SCW_IMAGE: '',
         DO_GATEWAY: 'gateway4.watchparty.me',

--- a/server/vm/docker.ts
+++ b/server/vm/docker.ts
@@ -32,7 +32,9 @@ export class Docker extends VMManager {
         INDEX=$(($PORT - 5000))
         UDP_START=$((59000+$INDEX*100))
         UDP_END=$((59099+$INDEX*100))
-        docker run -d --rm --name=${name} --net=host --memory="2g" --cpus="2" -v /etc/letsencrypt:/etc/letsencrypt -l ${this.getTag()} -l index=$INDEX --log-opt max-size=1g --shm-size=1g --cap-add="SYS_ADMIN" -e NEKO_KEY="/etc/letsencrypt/live/${gatewayHost}/privkey.pem" -e NEKO_CERT="/etc/letsencrypt/live/${gatewayHost}/fullchain.pem" -e DISPLAY=":$INDEX.0" -e NEKO_SCREEN="1280x720@30" -e NEKO_PASSWORD=${name} -e NEKO_PASSWORD_ADMIN=${name} -e NEKO_BIND=":$PORT" -e NEKO_EPR=":$UDP_START-$UDP_END" -e NEKO_H264="1" ${imageName}
+        docker run -d --rm --name=${name} --net=host --memory="2g" --cpus="2" -v /etc/letsencrypt:/etc/letsencrypt -l ${this.getTag()} -l index=$INDEX --log-opt max-size=1g --shm-size=1g --cap-add="SYS_ADMIN" -e NEKO_KEY="/etc/letsencrypt/live/${gatewayHost}/privkey.pem" -e NEKO_CERT="/etc/letsencrypt/live/${gatewayHost}/fullchain.pem" -e DISPLAY=":99.0" -e NEKO_SCREEN="${
+          this.isLarge ? '1920x1080@30' : ''
+        }" -e NEKO_PASSWORD=${name} -e NEKO_PASSWORD_ADMIN=${name} -e NEKO_BIND=":$PORT" -e NEKO_EPR=":$UDP_START-$UDP_END" -e NEKO_H264="1" ${imageName}
         `,
         sshConfig,
         (err: string, stdout: string) => {

--- a/server/vm/hetzner.ts
+++ b/server/vm/hetzner.ts
@@ -222,6 +222,8 @@ export class Hetzner extends VMManager {
         user_data: fs
           .readFileSync(__dirname + '/../../dev/vbrowser.sh')
           .toString(),
+        location:
+          this.datacenters[Math.floor(Math.random() * this.datacenters.length)],
       },
     });
     const id = response.data.server.id;

--- a/server/vm/utils.ts
+++ b/server/vm/utils.ts
@@ -22,12 +22,12 @@ ${
 }
 PASSWORD=$(hostname)
 # docker pull ${imageName}
-docker run -d --rm --name=vbrowser -v /usr/share/fonts:/usr/share/fonts --log-opt max-size=1g --net=host --shm-size=1g --cap-add="SYS_ADMIN" -e DISPLAY=":99.0" -e NEKO_SCREEN="${resolution}" -e NEKO_PASSWORD=$PASSWORD -e NEKO_PASSWORD_ADMIN=$PASSWORD -e NEKO_BIND=":5000" -e NEKO_EPR=":59000-59100" -e NEKO_VP9="${
+docker run -d --rm --name=vbrowser --log-opt max-size=1g --net=host --shm-size=1g --cap-add="SYS_ADMIN" -e DISPLAY=":99.0" -e NEKO_SCREEN="${resolution}" -e NEKO_PASSWORD=$PASSWORD -e NEKO_PASSWORD_ADMIN=$PASSWORD -e NEKO_BIND=":5000" -e NEKO_EPR=":59000-59100" -e NEKO_VP9="${
   vp9 ? 1 : 0
 }" -e NEKO_H264="${h264 ? 1 : 0}" ${imageName}
 `;
 
-export const imageName = 'howardc93/vbrowser';
+export const imageName = 'howardc93/vbrowser2';
 
 export const assignVM = async (
   redis: Redis.Redis,
@@ -200,6 +200,14 @@ export function getBgVMManagers(): { [key: string]: VMManager | null } {
     {
       provider: 'Docker',
       isLarge: true,
+      region: 'US',
+      limitSize: 0,
+      minSize: 0,
+      minBuffer: 0,
+    },
+    {
+      provider: 'Docker',
+      isLarge: false,
       region: 'US',
       limitSize: 0,
       minSize: 0,

--- a/server/vm/utils.ts
+++ b/server/vm/utils.ts
@@ -74,7 +74,7 @@ export const assignVM = async (
     const assignEnd = Number(new Date());
     const assignElapsed = assignEnd - assignStart;
     await redis.lpush('vBrowserStartMS', assignElapsed);
-    await redis.ltrim('vBrowserStartMS', 0, 99);
+    await redis.ltrim('vBrowserStartMS', 0, 24);
     console.log('[ASSIGN]', selected.id, assignElapsed + 'ms');
     const retVal = { ...selected, assignTime: Number(new Date()) };
     return retVal;

--- a/server/vmWorker.ts
+++ b/server/vmWorker.ts
@@ -66,7 +66,7 @@ app.post('/releaseVM', async (req, res) => {
   return res.end();
 });
 
-// curl -X POST http://localhost:3100/updateSnapshot -H 'Content-Type: application/json' -d '{"provider":"Hetzner","isLarge":false,"region":""}'
+// curl -X POST http://localhost:3100/updateSnapshot -H 'Content-Type: application/json' -d '{"provider":"Hetzner","isLarge":false,"region":"US"}'
 app.post('/updateSnapshot', async (req, res) => {
   const pool =
     vmManagers[

--- a/src/components/VBrowser/base.ts
+++ b/src/components/VBrowser/base.ts
@@ -4,19 +4,30 @@ import { iceServers } from '../../utils';
 import { OPCODE } from './data';
 import { EVENT, WebSocketEvents } from './events';
 import {
-  SignalProvidePayload,
   WebSocketMessages,
   WebSocketPayloads,
+  SignalProvidePayload,
+  SignalCandidatePayload,
+  SignalOfferPayload,
+  SignalAnswerMessage,
 } from './messages';
+
+// export interface BaseEvents {
+//   info: (...message: any[]) => void;
+//   warn: (...message: any[]) => void;
+//   debug: (...message: any[]) => void;
+//   error: (error: Error) => void;
+// }
 
 export abstract class BaseClient extends EventEmitter<any> {
   protected _ws?: WebSocket;
   protected _peer?: RTCPeerConnection;
   protected _channel?: RTCDataChannel;
-  protected _timeout?: NodeJS.Timeout;
+  protected _timeout?: number;
   protected _displayname?: string;
   protected _state: RTCIceConnectionState = 'disconnected';
   protected _id = '';
+  protected _candidates: RTCIceCandidate[] = [];
 
   get id() {
     return this._id;
@@ -59,21 +70,19 @@ export abstract class BaseClient extends EventEmitter<any> {
       return;
     }
 
-    if (displayname === '') {
-      throw new Error('Must add a displayname');
-    }
-
     this._displayname = displayname;
     this[EVENT.CONNECTING]();
 
     try {
-      this._ws = new WebSocket(`${url}ws?password=${password}`);
+      this._ws = new WebSocket(
+        `${url}?password=${encodeURIComponent(password)}`
+      );
       this.emit('debug', `connecting to ${this._ws.url}`);
       this._ws.onmessage = this.onMessage.bind(this);
       this._ws.onerror = (event) => this.onError.bind(this);
       this._ws.onclose = (event) =>
         this.onDisconnected.bind(this, new Error('websocket closed'));
-      this._timeout = setTimeout(this.onTimeout.bind(this), 15000);
+      this._timeout = window.setTimeout(this.onTimeout.bind(this), 15000);
     } catch (err: any) {
       this.onDisconnected(err);
     }
@@ -82,19 +91,46 @@ export abstract class BaseClient extends EventEmitter<any> {
   protected disconnect() {
     if (this._timeout) {
       clearTimeout(this._timeout);
+      this._timeout = undefined;
     }
 
-    if (this.socketOpen) {
+    if (this._ws) {
+      // reset all events
+      this._ws.onmessage = () => {};
+      this._ws.onerror = () => {};
+      this._ws.onclose = () => {};
+
       try {
-        this._ws!.close();
+        this._ws.close();
       } catch (err) {}
+
       this._ws = undefined;
     }
 
-    if (this.peerConnected) {
+    if (this._channel) {
+      // reset all events
+      this._channel.onmessage = () => {};
+      this._channel.onerror = () => {};
+      this._channel.onclose = () => {};
+
       try {
-        this._peer!.close();
+        this._channel.close();
       } catch (err) {}
+
+      this._channel = undefined;
+    }
+
+    if (this._peer) {
+      // reset all events
+      this._peer.onconnectionstatechange = () => {};
+      this._peer.onsignalingstatechange = () => {};
+      this._peer.oniceconnectionstatechange = () => {};
+      this._peer.ontrack = () => {};
+
+      try {
+        this._peer.close();
+      } catch (err) {}
+
       this._peer = undefined;
     }
 
@@ -138,19 +174,19 @@ export abstract class BaseClient extends EventEmitter<any> {
         break;
       case 'keydown':
       case 'mousedown':
-        buffer = new ArrayBuffer(5);
+        buffer = new ArrayBuffer(11);
         payload = new DataView(buffer);
         payload.setUint8(0, OPCODE.KEY_DOWN);
-        payload.setUint16(1, 1, true);
-        payload.setUint16(3, data.key, true);
+        payload.setUint16(1, 8, true);
+        payload.setBigUint64(3, BigInt(data.key), true);
         break;
       case 'keyup':
       case 'mouseup':
-        buffer = new ArrayBuffer(5);
+        buffer = new ArrayBuffer(11);
         payload = new DataView(buffer);
         payload.setUint8(0, OPCODE.KEY_UP);
-        payload.setUint16(1, 1, true);
-        payload.setUint16(3, data.key, true);
+        payload.setUint16(1, 8, true);
+        payload.setBigUint64(3, BigInt(data.key), true);
         break;
       default:
         this.emit('warn', `unknown data event: ${event}`);
@@ -175,7 +211,7 @@ export abstract class BaseClient extends EventEmitter<any> {
     this._ws!.send(JSON.stringify({ event, ...payload }));
   }
 
-  public createPeer(sdp: string, lite: boolean, servers: string[]) {
+  public async createPeer(lite: boolean, servers: RTCIceServer[]) {
     this.emit('debug', `creating peer`);
     if (!this.socketOpen) {
       this.emit(
@@ -194,7 +230,7 @@ export abstract class BaseClient extends EventEmitter<any> {
     this._peer = new RTCPeerConnection();
     if (lite !== true) {
       this._peer = new RTCPeerConnection({
-        iceServers: servers ? [{ urls: servers }] : iceServers(),
+        iceServers: servers,
       });
     }
 
@@ -226,23 +262,43 @@ export abstract class BaseClient extends EventEmitter<any> {
         case 'checking':
           if (this._timeout) {
             clearTimeout(this._timeout);
+            this._timeout = undefined;
           }
           break;
         case 'connected':
           this.onConnected();
           break;
+        case 'disconnected':
+          this[EVENT.RECONNECTING]();
+          break;
+        // https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling#ice_connection_state
+        // We don't watch the disconnected signaling state here as it can indicate temporary issues and may
+        // go back to a connected state after some time. Watching it would close the video call on any temporary
+        // network issue.
         case 'failed':
           this.onDisconnected(new Error('peer failed'));
           break;
-        case 'disconnected':
-          this.onDisconnected(new Error('peer disconnected'));
+        case 'closed':
+          this.onDisconnected(new Error('peer closed'));
           break;
       }
     };
 
     this._peer.ontrack = this.onTrack.bind(this);
-    this._peer.addTransceiver('audio', { direction: 'recvonly' });
-    this._peer.addTransceiver('video', { direction: 'recvonly' });
+
+    this._peer.onnegotiationneeded = async () => {
+      this.emit('warn', `negotiation is needed`);
+
+      const d = await this._peer!.createOffer();
+      this._peer!.setLocalDescription(d);
+
+      this._ws!.send(
+        JSON.stringify({
+          event: EVENT.SIGNAL.OFFER,
+          sdp: d.sdp,
+        })
+      );
+    };
 
     this._channel = this._peer.createDataChannel('data');
     this._channel.onerror = this.onError.bind(this);
@@ -251,24 +307,47 @@ export abstract class BaseClient extends EventEmitter<any> {
       this,
       new Error('peer data channel closed')
     );
-
-    this._peer.setRemoteDescription({ type: 'offer', sdp });
-    this._peer
-      .createAnswer()
-      .then((d) => {
-        this._peer!.setLocalDescription(d);
-        this._ws!.send(
-          JSON.stringify({
-            event: EVENT.SIGNAL.ANSWER,
-            sdp: d.sdp,
-            displayname: this._displayname,
-          })
-        );
-      })
-      .catch((err) => this.emit('error', err));
   }
 
-  private onMessage(e: MessageEvent) {
+  public async setRemoteOffer(sdp: string) {
+    if (!this._peer) {
+      this.emit('warn', `attempting to set remote offer while disconnected`);
+      return;
+    }
+
+    this._peer.setRemoteDescription({ type: 'offer', sdp });
+
+    for (const candidate of this._candidates) {
+      this._peer.addIceCandidate(candidate);
+    }
+    this._candidates = [];
+
+    try {
+      const d = await this._peer.createAnswer();
+      this._peer!.setLocalDescription(d);
+
+      this._ws!.send(
+        JSON.stringify({
+          event: EVENT.SIGNAL.ANSWER,
+          sdp: d.sdp,
+          displayname: this._displayname,
+        })
+      );
+    } catch (err: any) {
+      this.emit('error', err);
+    }
+  }
+
+  public async setRemoteAnswer(sdp: string) {
+    if (!this._peer) {
+      this.emit('warn', `attempting to set remote answer while disconnected`);
+      return;
+    }
+
+    this._peer.setRemoteDescription({ type: 'answer', sdp });
+  }
+
+  private async onMessage(e: MessageEvent) {
     const { event, ...payload } = JSON.parse(e.data) as WebSocketMessages;
 
     this.emit(
@@ -280,7 +359,31 @@ export abstract class BaseClient extends EventEmitter<any> {
     if (event === EVENT.SIGNAL.PROVIDE) {
       const { sdp, lite, ice, id } = payload as SignalProvidePayload;
       this._id = id;
-      this.createPeer(sdp, lite, ice);
+      await this.createPeer(lite, ice);
+      await this.setRemoteOffer(sdp);
+      return;
+    }
+
+    if (event === EVENT.SIGNAL.OFFER) {
+      const { sdp } = payload as SignalOfferPayload;
+      await this.setRemoteOffer(sdp);
+      return;
+    }
+
+    if (event === EVENT.SIGNAL.ANSWER) {
+      const { sdp } = payload as SignalAnswerMessage;
+      await this.setRemoteAnswer(sdp);
+      return;
+    }
+
+    if (event === EVENT.SIGNAL.CANDIDATE) {
+      const { data } = payload as SignalCandidatePayload;
+      const candidate: RTCIceCandidate = JSON.parse(data);
+      if (this._peer) {
+        this._peer.addIceCandidate(candidate);
+      } else {
+        this._candidates.push(candidate);
+      }
       return;
     }
 
@@ -321,6 +424,7 @@ export abstract class BaseClient extends EventEmitter<any> {
   private onConnected() {
     if (this._timeout) {
       clearTimeout(this._timeout);
+      this._timeout = undefined;
     }
 
     if (!this.connected) {
@@ -336,6 +440,7 @@ export abstract class BaseClient extends EventEmitter<any> {
     this.emit('debug', `connection timeout`);
     if (this._timeout) {
       clearTimeout(this._timeout);
+      this._timeout = undefined;
     }
     this.onDisconnected(new Error('connection timeout'));
   }
@@ -350,6 +455,7 @@ export abstract class BaseClient extends EventEmitter<any> {
     this.emit('warn', `unhandled websocket event '${event}':`, payload);
   }
 
+  protected abstract [EVENT.RECONNECTING](): void;
   protected abstract [EVENT.CONNECTING](): void;
   protected abstract [EVENT.CONNECTED](): void;
   protected abstract [EVENT.DISCONNECTED](reason?: Error): void;

--- a/src/components/VBrowser/base.ts
+++ b/src/components/VBrowser/base.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'eventemitter3';
 
-import { iceServers } from '../../utils';
+// import { iceServers } from '../../utils';
 import { OPCODE } from './data';
 import { EVENT, WebSocketEvents } from './events';
 import {

--- a/src/components/VBrowser/events.ts
+++ b/src/components/VBrowser/events.ts
@@ -1,5 +1,6 @@
 export const EVENT = {
   // Internal Events
+  RECONNECTING: 'RECONNECTING',
   CONNECTING: 'CONNECTING',
   CONNECTED: 'CONNECTED',
   DISCONNECTED: 'DISCONNECTED',
@@ -9,11 +10,15 @@ export const EVENT = {
 
   // Websocket Events
   SYSTEM: {
+    INIT: 'system/init',
     DISCONNECT: 'system/disconnect',
+    ERROR: 'system/error',
   },
   SIGNAL: {
+    OFFER: 'signal/offer',
     ANSWER: 'signal/answer',
     PROVIDE: 'signal/provide',
+    CANDIDATE: 'signal/candidate',
   },
   MEMBER: {
     LIST: 'member/list',
@@ -27,6 +32,7 @@ export const EVENT = {
     REQUESTING: 'control/requesting',
     CLIPBOARD: 'control/clipboard',
     GIVE: 'control/give',
+    KEYBOARD: 'control/keyboard',
   },
   CHAT: {
     MESSAGE: 'chat/message',
@@ -36,6 +42,11 @@ export const EVENT = {
     CONFIGURATIONS: 'screen/configurations',
     RESOLUTION: 'screen/resolution',
     SET: 'screen/set',
+  },
+  BROADCAST: {
+    STATUS: 'broadcast/status',
+    CREATE: 'broadcast/create',
+    DESTROY: 'broadcast/destroy',
   },
   ADMIN: {
     BAN: 'admin/ban',
@@ -59,6 +70,7 @@ export type WebSocketEvents =
   | SignalEvents
   | ChatEvents
   | ScreenEvents
+  | BroadcastEvents
   | AdminEvents
   | 'ka';
 
@@ -67,21 +79,31 @@ export type ControlEvents =
   | typeof EVENT.CONTROL.RELEASE
   | typeof EVENT.CONTROL.REQUEST
   | typeof EVENT.CONTROL.GIVE
-  | typeof EVENT.CONTROL.CLIPBOARD;
+  | typeof EVENT.CONTROL.CLIPBOARD
+  | typeof EVENT.CONTROL.KEYBOARD;
 
 export type SystemEvents = typeof EVENT.SYSTEM.DISCONNECT;
 export type MemberEvents =
   | typeof EVENT.MEMBER.LIST
   | typeof EVENT.MEMBER.CONNECTED
   | typeof EVENT.MEMBER.DISCONNECTED;
+
 export type SignalEvents =
+  | typeof EVENT.SIGNAL.OFFER
   | typeof EVENT.SIGNAL.ANSWER
-  | typeof EVENT.SIGNAL.PROVIDE;
+  | typeof EVENT.SIGNAL.PROVIDE
+  | typeof EVENT.SIGNAL.CANDIDATE;
+
 export type ChatEvents = typeof EVENT.CHAT.MESSAGE | typeof EVENT.CHAT.EMOTE;
 export type ScreenEvents =
   | typeof EVENT.SCREEN.CONFIGURATIONS
   | typeof EVENT.SCREEN.RESOLUTION
   | typeof EVENT.SCREEN.SET;
+
+export type BroadcastEvents =
+  | typeof EVENT.BROADCAST.STATUS
+  | typeof EVENT.BROADCAST.CREATE
+  | typeof EVENT.BROADCAST.DESTROY;
 
 export type AdminEvents =
   | typeof EVENT.ADMIN.BAN

--- a/src/components/VBrowser/guacamole-keyboard.js
+++ b/src/components/VBrowser/guacamole-keyboard.js
@@ -1,0 +1,1477 @@
+/* eslint-disable */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var Guacamole = Guacamole || {};
+
+/**
+ * Provides cross-browser and cross-keyboard keyboard for a specific element.
+ * Browser and keyboard layout variation is abstracted away, providing events
+ * which represent keys as their corresponding X11 keysym.
+ *
+ * @constructor
+ * @param {Element|Document} [element]
+ *    The Element to use to provide keyboard events. If omitted, at least one
+ *    Element must be manually provided through the listenTo() function for
+ *    the Guacamole.Keyboard instance to have any effect.
+ */
+Guacamole.Keyboard = function Keyboard(element) {
+  /**
+   * Reference to this Guacamole.Keyboard.
+   * @private
+   */
+  var guac_keyboard = this;
+
+  /**
+   * An integer value which uniquely identifies this Guacamole.Keyboard
+   * instance with respect to other Guacamole.Keyboard instances.
+   *
+   * @private
+   * @type {Number}
+   */
+  var guacKeyboardID = Guacamole.Keyboard._nextID++;
+
+  /**
+   * The name of the property which is added to event objects via markEvent()
+   * to note that they have already been handled by this Guacamole.Keyboard.
+   *
+   * @private
+   * @constant
+   * @type {String}
+   */
+  var EVENT_MARKER = '_GUAC_KEYBOARD_HANDLED_BY_' + guacKeyboardID;
+
+  /**
+   * Fired whenever the user presses a key with the element associated
+   * with this Guacamole.Keyboard in focus.
+   *
+   * @event
+   * @param {Number} keysym The keysym of the key being pressed.
+   * @return {Boolean} true if the key event should be allowed through to the
+   *                   browser, false otherwise.
+   */
+  this.onkeydown = null;
+
+  /**
+   * Fired whenever the user releases a key with the element associated
+   * with this Guacamole.Keyboard in focus.
+   *
+   * @event
+   * @param {Number} keysym The keysym of the key being released.
+   */
+  this.onkeyup = null;
+
+  /**
+   * Set of known platform-specific or browser-specific quirks which must be
+   * accounted for to properly interpret key events, even if the only way to
+   * reliably detect that quirk is to platform/browser-sniff.
+   *
+   * @private
+   * @type {Object.<String, Boolean>}
+   */
+  var quirks = {
+    /**
+     * Whether keyup events are universally unreliable.
+     *
+     * @type {Boolean}
+     */
+    keyupUnreliable: false,
+
+    /**
+     * Whether the Alt key is actually a modifier for typable keys and is
+     * thus never used for keyboard shortcuts.
+     *
+     * @type {Boolean}
+     */
+    altIsTypableOnly: false,
+
+    /**
+     * Whether we can rely on receiving a keyup event for the Caps Lock
+     * key.
+     *
+     * @type {Boolean}
+     */
+    capsLockKeyupUnreliable: false,
+  };
+
+  // Set quirk flags depending on platform/browser, if such information is
+  // available
+  if (navigator && navigator.platform) {
+    // All keyup events are unreliable on iOS (sadly)
+    if (navigator.platform.match(/ipad|iphone|ipod/i))
+      quirks.keyupUnreliable = true;
+    // The Alt key on Mac is never used for keyboard shortcuts, and the
+    // Caps Lock key never dispatches keyup events
+    else if (navigator.platform.match(/^mac/i)) {
+      quirks.altIsTypableOnly = true;
+      quirks.capsLockKeyupUnreliable = true;
+    }
+  }
+
+  /**
+   * A key event having a corresponding timestamp. This event is non-specific.
+   * Its subclasses should be used instead when recording specific key
+   * events.
+   *
+   * @private
+   * @constructor
+   */
+  var KeyEvent = function () {
+    /**
+     * Reference to this key event.
+     */
+    var key_event = this;
+
+    /**
+     * An arbitrary timestamp in milliseconds, indicating this event's
+     * position in time relative to other events.
+     *
+     * @type {Number}
+     */
+    this.timestamp = new Date().getTime();
+
+    /**
+     * Whether the default action of this key event should be prevented.
+     *
+     * @type {Boolean}
+     */
+    this.defaultPrevented = false;
+
+    /**
+     * The keysym of the key associated with this key event, as determined
+     * by a best-effort guess using available event properties and keyboard
+     * state.
+     *
+     * @type {Number}
+     */
+    this.keysym = null;
+
+    /**
+     * Whether the keysym value of this key event is known to be reliable.
+     * If false, the keysym may still be valid, but it's only a best guess,
+     * and future key events may be a better source of information.
+     *
+     * @type {Boolean}
+     */
+    this.reliable = false;
+
+    /**
+     * Returns the number of milliseconds elapsed since this event was
+     * received.
+     *
+     * @return {Number} The number of milliseconds elapsed since this
+     *                  event was received.
+     */
+    this.getAge = function () {
+      return new Date().getTime() - key_event.timestamp;
+    };
+  };
+
+  /**
+   * Information related to the pressing of a key, which need not be a key
+   * associated with a printable character. The presence or absence of any
+   * information within this object is browser-dependent.
+   *
+   * @private
+   * @constructor
+   * @augments Guacamole.Keyboard.KeyEvent
+   * @param {Number} keyCode The JavaScript key code of the key pressed.
+   * @param {String} keyIdentifier The legacy DOM3 "keyIdentifier" of the key
+   *                               pressed, as defined at:
+   *                               http://www.w3.org/TR/2009/WD-DOM-Level-3-Events-20090908/#events-Events-KeyboardEvent
+   * @param {String} key The standard name of the key pressed, as defined at:
+   *                     http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+   * @param {Number} location The location on the keyboard corresponding to
+   *                          the key pressed, as defined at:
+   *                          http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+   */
+  var KeydownEvent = function (keyCode, keyIdentifier, key, location) {
+    // We extend KeyEvent
+    KeyEvent.apply(this);
+
+    /**
+     * The JavaScript key code of the key pressed.
+     *
+     * @type {Number}
+     */
+    this.keyCode = keyCode;
+
+    /**
+     * The legacy DOM3 "keyIdentifier" of the key pressed, as defined at:
+     * http://www.w3.org/TR/2009/WD-DOM-Level-3-Events-20090908/#events-Events-KeyboardEvent
+     *
+     * @type {String}
+     */
+    this.keyIdentifier = keyIdentifier;
+
+    /**
+     * The standard name of the key pressed, as defined at:
+     * http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+     *
+     * @type {String}
+     */
+    this.key = key;
+
+    /**
+     * The location on the keyboard corresponding to the key pressed, as
+     * defined at:
+     * http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+     *
+     * @type {Number}
+     */
+    this.location = location;
+
+    // If key is known from keyCode or DOM3 alone, use that
+    this.keysym =
+      keysym_from_key_identifier(key, location) ||
+      keysym_from_keycode(keyCode, location);
+
+    /**
+     * Whether the keyup following this keydown event is known to be
+     * reliable. If false, we cannot rely on the keyup event to occur.
+     *
+     * @type {Boolean}
+     */
+    this.keyupReliable = !quirks.keyupUnreliable;
+
+    // DOM3 and keyCode are reliable sources if the corresponding key is
+    // not a printable key
+    if (this.keysym && !isPrintable(this.keysym)) this.reliable = true;
+
+    // Use legacy keyIdentifier as a last resort, if it looks sane
+    if (!this.keysym && key_identifier_sane(keyCode, keyIdentifier))
+      this.keysym = keysym_from_key_identifier(
+        keyIdentifier,
+        location,
+        guac_keyboard.modifiers.shift
+      );
+
+    // If a key is pressed while meta is held down, the keyup will
+    // never be sent in Chrome (bug #108404)
+    if (
+      guac_keyboard.modifiers.meta &&
+      this.keysym !== 0xffe7 &&
+      this.keysym !== 0xffe8
+    )
+      this.keyupReliable = false;
+    // We cannot rely on receiving keyup for Caps Lock on certain platforms
+    else if (this.keysym === 0xffe5 && quirks.capsLockKeyupUnreliable)
+      this.keyupReliable = false;
+
+    // Determine whether default action for Alt+combinations must be prevented
+    var prevent_alt = !guac_keyboard.modifiers.ctrl && !quirks.altIsTypableOnly;
+
+    // Determine whether default action for Ctrl+combinations must be prevented
+    var prevent_ctrl = !guac_keyboard.modifiers.alt;
+
+    // We must rely on the (potentially buggy) keyIdentifier if preventing
+    // the default action is important
+    if (
+      (prevent_ctrl && guac_keyboard.modifiers.ctrl) ||
+      (prevent_alt && guac_keyboard.modifiers.alt) ||
+      guac_keyboard.modifiers.meta ||
+      guac_keyboard.modifiers.hyper
+    )
+      this.reliable = true;
+
+    // Record most recently known keysym by associated key code
+    recentKeysym[keyCode] = this.keysym;
+  };
+
+  KeydownEvent.prototype = new KeyEvent();
+
+  /**
+   * Information related to the pressing of a key, which MUST be
+   * associated with a printable character. The presence or absence of any
+   * information within this object is browser-dependent.
+   *
+   * @private
+   * @constructor
+   * @augments Guacamole.Keyboard.KeyEvent
+   * @param {Number} charCode The Unicode codepoint of the character that
+   *                          would be typed by the key pressed.
+   */
+  var KeypressEvent = function (charCode) {
+    // We extend KeyEvent
+    KeyEvent.apply(this);
+
+    /**
+     * The Unicode codepoint of the character that would be typed by the
+     * key pressed.
+     *
+     * @type {Number}
+     */
+    this.charCode = charCode;
+
+    // Pull keysym from char code
+    this.keysym = keysym_from_charcode(charCode);
+
+    // Keypress is always reliable
+    this.reliable = true;
+  };
+
+  KeypressEvent.prototype = new KeyEvent();
+
+  /**
+   * Information related to the pressing of a key, which need not be a key
+   * associated with a printable character. The presence or absence of any
+   * information within this object is browser-dependent.
+   *
+   * @private
+   * @constructor
+   * @augments Guacamole.Keyboard.KeyEvent
+   * @param {Number} keyCode The JavaScript key code of the key released.
+   * @param {String} keyIdentifier The legacy DOM3 "keyIdentifier" of the key
+   *                               released, as defined at:
+   *                               http://www.w3.org/TR/2009/WD-DOM-Level-3-Events-20090908/#events-Events-KeyboardEvent
+   * @param {String} key The standard name of the key released, as defined at:
+   *                     http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+   * @param {Number} location The location on the keyboard corresponding to
+   *                          the key released, as defined at:
+   *                          http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+   */
+  var KeyupEvent = function (keyCode, keyIdentifier, key, location) {
+    // We extend KeyEvent
+    KeyEvent.apply(this);
+
+    /**
+     * The JavaScript key code of the key released.
+     *
+     * @type {Number}
+     */
+    this.keyCode = keyCode;
+
+    /**
+     * The legacy DOM3 "keyIdentifier" of the key released, as defined at:
+     * http://www.w3.org/TR/2009/WD-DOM-Level-3-Events-20090908/#events-Events-KeyboardEvent
+     *
+     * @type {String}
+     */
+    this.keyIdentifier = keyIdentifier;
+
+    /**
+     * The standard name of the key released, as defined at:
+     * http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+     *
+     * @type {String}
+     */
+    this.key = key;
+
+    /**
+     * The location on the keyboard corresponding to the key released, as
+     * defined at:
+     * http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+     *
+     * @type {Number}
+     */
+    this.location = location;
+
+    // If key is known from keyCode or DOM3 alone, use that
+    this.keysym =
+      keysym_from_keycode(keyCode, location) ||
+      keysym_from_key_identifier(key, location); // keyCode is still more reliable for keyup when dead keys are in use
+
+    // Fall back to the most recently pressed keysym associated with the
+    // keyCode if the inferred key doesn't seem to actually be pressed
+    if (!guac_keyboard.pressed[this.keysym])
+      this.keysym = recentKeysym[keyCode] || this.keysym;
+
+    // Keyup is as reliable as it will ever be
+    this.reliable = true;
+  };
+
+  KeyupEvent.prototype = new KeyEvent();
+
+  /**
+   * An array of recorded events, which can be instances of the private
+   * KeydownEvent, KeypressEvent, and KeyupEvent classes.
+   *
+   * @private
+   * @type {KeyEvent[]}
+   */
+  var eventLog = [];
+
+  /**
+   * Map of known JavaScript keycodes which do not map to typable characters
+   * to their X11 keysym equivalents.
+   * @private
+   */
+  var keycodeKeysyms = {
+    8: [0xff08], // backspace
+    9: [0xff09], // tab
+    12: [0xff0b, 0xff0b, 0xff0b, 0xffb5], // clear       / KP 5
+    13: [0xff0d], // enter
+    16: [0xffe1, 0xffe1, 0xffe2], // shift
+    17: [0xffe3, 0xffe3, 0xffe4], // ctrl
+    18: [0xffe9, 0xffe9, 0xfe03], // alt
+    19: [0xff13], // pause/break
+    20: [0xffe5], // caps lock
+    27: [0xff1b], // escape
+    32: [0x0020], // space
+    33: [0xff55, 0xff55, 0xff55, 0xffb9], // page up     / KP 9
+    34: [0xff56, 0xff56, 0xff56, 0xffb3], // page down   / KP 3
+    35: [0xff57, 0xff57, 0xff57, 0xffb1], // end         / KP 1
+    36: [0xff50, 0xff50, 0xff50, 0xffb7], // home        / KP 7
+    37: [0xff51, 0xff51, 0xff51, 0xffb4], // left arrow  / KP 4
+    38: [0xff52, 0xff52, 0xff52, 0xffb8], // up arrow    / KP 8
+    39: [0xff53, 0xff53, 0xff53, 0xffb6], // right arrow / KP 6
+    40: [0xff54, 0xff54, 0xff54, 0xffb2], // down arrow  / KP 2
+    45: [0xff63, 0xff63, 0xff63, 0xffb0], // insert      / KP 0
+    46: [0xffff, 0xffff, 0xffff, 0xffae], // delete      / KP decimal
+    91: [0xffeb], // left window key (hyper_l)
+    92: [0xff67], // right window key (menu key?)
+    93: null, // select key
+    96: [0xffb0], // KP 0
+    97: [0xffb1], // KP 1
+    98: [0xffb2], // KP 2
+    99: [0xffb3], // KP 3
+    100: [0xffb4], // KP 4
+    101: [0xffb5], // KP 5
+    102: [0xffb6], // KP 6
+    103: [0xffb7], // KP 7
+    104: [0xffb8], // KP 8
+    105: [0xffb9], // KP 9
+    106: [0xffaa], // KP multiply
+    107: [0xffab], // KP add
+    109: [0xffad], // KP subtract
+    110: [0xffae], // KP decimal
+    111: [0xffaf], // KP divide
+    112: [0xffbe], // f1
+    113: [0xffbf], // f2
+    114: [0xffc0], // f3
+    115: [0xffc1], // f4
+    116: [0xffc2], // f5
+    117: [0xffc3], // f6
+    118: [0xffc4], // f7
+    119: [0xffc5], // f8
+    120: [0xffc6], // f9
+    121: [0xffc7], // f10
+    122: [0xffc8], // f11
+    123: [0xffc9], // f12
+    144: [0xff7f], // num lock
+    145: [0xff14], // scroll lock
+    225: [0xfe03], // altgraph (iso_level3_shift)
+  };
+
+  /**
+   * Map of known JavaScript keyidentifiers which do not map to typable
+   * characters to their unshifted X11 keysym equivalents.
+   * @private
+   */
+  var keyidentifier_keysym = {
+    Again: [0xff66],
+    AllCandidates: [0xff3d],
+    Alphanumeric: [0xff30],
+    Alt: [0xffe9, 0xffe9, 0xfe03],
+    Attn: [0xfd0e],
+    AltGraph: [0xfe03],
+    ArrowDown: [0xff54],
+    ArrowLeft: [0xff51],
+    ArrowRight: [0xff53],
+    ArrowUp: [0xff52],
+    Backspace: [0xff08],
+    CapsLock: [0xffe5],
+    Cancel: [0xff69],
+    Clear: [0xff0b],
+    Convert: [0xff21],
+    Copy: [0xfd15],
+    Crsel: [0xfd1c],
+    CrSel: [0xfd1c],
+    CodeInput: [0xff37],
+    Compose: [0xff20],
+    Control: [0xffe3, 0xffe3, 0xffe4],
+    ContextMenu: [0xff67],
+    Delete: [0xffff],
+    Down: [0xff54],
+    End: [0xff57],
+    Enter: [0xff0d],
+    EraseEof: [0xfd06],
+    Escape: [0xff1b],
+    Execute: [0xff62],
+    Exsel: [0xfd1d],
+    ExSel: [0xfd1d],
+    F1: [0xffbe],
+    F2: [0xffbf],
+    F3: [0xffc0],
+    F4: [0xffc1],
+    F5: [0xffc2],
+    F6: [0xffc3],
+    F7: [0xffc4],
+    F8: [0xffc5],
+    F9: [0xffc6],
+    F10: [0xffc7],
+    F11: [0xffc8],
+    F12: [0xffc9],
+    F13: [0xffca],
+    F14: [0xffcb],
+    F15: [0xffcc],
+    F16: [0xffcd],
+    F17: [0xffce],
+    F18: [0xffcf],
+    F19: [0xffd0],
+    F20: [0xffd1],
+    F21: [0xffd2],
+    F22: [0xffd3],
+    F23: [0xffd4],
+    F24: [0xffd5],
+    Find: [0xff68],
+    GroupFirst: [0xfe0c],
+    GroupLast: [0xfe0e],
+    GroupNext: [0xfe08],
+    GroupPrevious: [0xfe0a],
+    FullWidth: null,
+    HalfWidth: null,
+    HangulMode: [0xff31],
+    Hankaku: [0xff29],
+    HanjaMode: [0xff34],
+    Help: [0xff6a],
+    Hiragana: [0xff25],
+    HiraganaKatakana: [0xff27],
+    Home: [0xff50],
+    Hyper: [0xffed, 0xffed, 0xffee],
+    Insert: [0xff63],
+    JapaneseHiragana: [0xff25],
+    JapaneseKatakana: [0xff26],
+    JapaneseRomaji: [0xff24],
+    JunjaMode: [0xff38],
+    KanaMode: [0xff2d],
+    KanjiMode: [0xff21],
+    Katakana: [0xff26],
+    Left: [0xff51],
+    Meta: [0xffe7, 0xffe7, 0xffe8],
+    ModeChange: [0xff7e],
+    NumLock: [0xff7f],
+    PageDown: [0xff56],
+    PageUp: [0xff55],
+    Pause: [0xff13],
+    Play: [0xfd16],
+    PreviousCandidate: [0xff3e],
+    PrintScreen: [0xff61],
+    Redo: [0xff66],
+    Right: [0xff53],
+    RomanCharacters: null,
+    Scroll: [0xff14],
+    Select: [0xff60],
+    Separator: [0xffac],
+    Shift: [0xffe1, 0xffe1, 0xffe2],
+    SingleCandidate: [0xff3c],
+    Super: [0xffeb, 0xffeb, 0xffec],
+    Tab: [0xff09],
+    UIKeyInputDownArrow: [0xff54],
+    UIKeyInputEscape: [0xff1b],
+    UIKeyInputLeftArrow: [0xff51],
+    UIKeyInputRightArrow: [0xff53],
+    UIKeyInputUpArrow: [0xff52],
+    Up: [0xff52],
+    Undo: [0xff65],
+    Win: [0xffeb],
+    Zenkaku: [0xff28],
+    ZenkakuHankaku: [0xff2a],
+  };
+
+  /**
+   * All keysyms which should not repeat when held down.
+   * @private
+   */
+  var no_repeat = {
+    0xfe03: true, // ISO Level 3 Shift (AltGr)
+    0xffe1: true, // Left shift
+    0xffe2: true, // Right shift
+    0xffe3: true, // Left ctrl
+    0xffe4: true, // Right ctrl
+    0xffe5: true, // Caps Lock
+    0xffe7: true, // Left meta
+    0xffe8: true, // Right meta
+    0xffe9: true, // Left alt
+    0xffea: true, // Right alt
+    0xffeb: true, // Left hyper
+    0xffec: true, // Right hyper
+  };
+
+  /**
+   * All modifiers and their states.
+   */
+  this.modifiers = new Guacamole.Keyboard.ModifierState();
+
+  /**
+   * The state of every key, indexed by keysym. If a particular key is
+   * pressed, the value of pressed for that keysym will be true. If a key
+   * is not currently pressed, it will not be defined.
+   */
+  this.pressed = {};
+
+  /**
+   * The state of every key, indexed by keysym, for strictly those keys whose
+   * status has been indirectly determined thorugh observation of other key
+   * events. If a particular key is implicitly pressed, the value of
+   * implicitlyPressed for that keysym will be true. If a key
+   * is not currently implicitly pressed (the key is not pressed OR the state
+   * of the key is explicitly known), it will not be defined.
+   *
+   * @private
+   * @tyle {Object.<Number, Boolean>}
+   */
+  var implicitlyPressed = {};
+
+  /**
+   * The last result of calling the onkeydown handler for each key, indexed
+   * by keysym. This is used to prevent/allow default actions for key events,
+   * even when the onkeydown handler cannot be called again because the key
+   * is (theoretically) still pressed.
+   *
+   * @private
+   */
+  var last_keydown_result = {};
+
+  /**
+   * The keysym most recently associated with a given keycode when keydown
+   * fired. This object maps keycodes to keysyms.
+   *
+   * @private
+   * @type {Object.<Number, Number>}
+   */
+  var recentKeysym = {};
+
+  /**
+   * Timeout before key repeat starts.
+   * @private
+   */
+  var key_repeat_timeout = null;
+
+  /**
+   * Interval which presses and releases the last key pressed while that
+   * key is still being held down.
+   * @private
+   */
+  var key_repeat_interval = null;
+
+  /**
+   * Given an array of keysyms indexed by location, returns the keysym
+   * for the given location, or the keysym for the standard location if
+   * undefined.
+   *
+   * @private
+   * @param {Number[]} keysyms
+   *     An array of keysyms, where the index of the keysym in the array is
+   *     the location value.
+   *
+   * @param {Number} location
+   *     The location on the keyboard corresponding to the key pressed, as
+   *     defined at: http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+   */
+  var get_keysym = function get_keysym(keysyms, location) {
+    if (!keysyms) return null;
+
+    return keysyms[location] || keysyms[0];
+  };
+
+  /**
+   * Returns true if the given keysym corresponds to a printable character,
+   * false otherwise.
+   *
+   * @param {Number} keysym
+   *     The keysym to check.
+   *
+   * @returns {Boolean}
+   *     true if the given keysym corresponds to a printable character,
+   *     false otherwise.
+   */
+  var isPrintable = function isPrintable(keysym) {
+    // Keysyms with Unicode equivalents are printable
+    return (
+      (keysym >= 0x00 && keysym <= 0xff) || (keysym & 0xffff0000) === 0x01000000
+    );
+  };
+
+  function keysym_from_key_identifier(identifier, location, shifted) {
+    if (!identifier) return null;
+
+    var typedCharacter;
+
+    // If identifier is U+xxxx, decode Unicode character
+    var unicodePrefixLocation = identifier.indexOf('U+');
+    if (unicodePrefixLocation >= 0) {
+      var hex = identifier.substring(unicodePrefixLocation + 2);
+      typedCharacter = String.fromCharCode(parseInt(hex, 16));
+    }
+
+    // If single character and not keypad, use that as typed character
+    else if (identifier.length === 1 && location !== 3)
+      typedCharacter = identifier;
+    // Otherwise, look up corresponding keysym
+    else return get_keysym(keyidentifier_keysym[identifier], location);
+
+    // Alter case if necessary
+    if (shifted === true) typedCharacter = typedCharacter.toUpperCase();
+    else if (shifted === false) typedCharacter = typedCharacter.toLowerCase();
+
+    // Get codepoint
+    var codepoint = typedCharacter.charCodeAt(0);
+    return keysym_from_charcode(codepoint);
+  }
+
+  function isControlCharacter(codepoint) {
+    return codepoint <= 0x1f || (codepoint >= 0x7f && codepoint <= 0x9f);
+  }
+
+  function keysym_from_charcode(codepoint) {
+    // Keysyms for control characters
+    if (isControlCharacter(codepoint)) return 0xff00 | codepoint;
+
+    // Keysyms for ASCII chars
+    if (codepoint >= 0x0000 && codepoint <= 0x00ff) return codepoint;
+
+    // Keysyms for Unicode
+    if (codepoint >= 0x0100 && codepoint <= 0x10ffff)
+      return 0x01000000 | codepoint;
+
+    return null;
+  }
+
+  function keysym_from_keycode(keyCode, location) {
+    return get_keysym(keycodeKeysyms[keyCode], location);
+  }
+
+  /**
+   * Heuristically detects if the legacy keyIdentifier property of
+   * a keydown/keyup event looks incorrectly derived. Chrome, and
+   * presumably others, will produce the keyIdentifier by assuming
+   * the keyCode is the Unicode codepoint for that key. This is not
+   * correct in all cases.
+   *
+   * @private
+   * @param {Number} keyCode
+   *     The keyCode from a browser keydown/keyup event.
+   *
+   * @param {String} keyIdentifier
+   *     The legacy keyIdentifier from a browser keydown/keyup event.
+   *
+   * @returns {Boolean}
+   *     true if the keyIdentifier looks sane, false if the keyIdentifier
+   *     appears incorrectly derived or is missing entirely.
+   */
+  var key_identifier_sane = function key_identifier_sane(
+    keyCode,
+    keyIdentifier
+  ) {
+    // Missing identifier is not sane
+    if (!keyIdentifier) return false;
+
+    // Assume non-Unicode keyIdentifier values are sane
+    var unicodePrefixLocation = keyIdentifier.indexOf('U+');
+    if (unicodePrefixLocation === -1) return true;
+
+    // If the Unicode codepoint isn't identical to the keyCode,
+    // then the identifier is likely correct
+    var codepoint = parseInt(
+      keyIdentifier.substring(unicodePrefixLocation + 2),
+      16
+    );
+    if (keyCode !== codepoint) return true;
+
+    // The keyCodes for A-Z and 0-9 are actually identical to their
+    // Unicode codepoints
+    if ((keyCode >= 65 && keyCode <= 90) || (keyCode >= 48 && keyCode <= 57))
+      return true;
+
+    // The keyIdentifier does NOT appear sane
+    return false;
+  };
+
+  /**
+   * Marks a key as pressed, firing the keydown event if registered. Key
+   * repeat for the pressed key will start after a delay if that key is
+   * not a modifier. The return value of this function depends on the
+   * return value of the keydown event handler, if any.
+   *
+   * @param {Number} keysym The keysym of the key to press.
+   * @return {Boolean} true if event should NOT be canceled, false otherwise.
+   */
+  this.press = function (keysym) {
+    // Don't bother with pressing the key if the key is unknown
+    if (keysym === null) return;
+
+    // Only press if released
+    if (!guac_keyboard.pressed[keysym]) {
+      // Mark key as pressed
+      guac_keyboard.pressed[keysym] = true;
+
+      // Send key event
+      if (guac_keyboard.onkeydown) {
+        var result = guac_keyboard.onkeydown(keysym);
+        last_keydown_result[keysym] = result;
+
+        // Stop any current repeat
+        window.clearTimeout(key_repeat_timeout);
+        window.clearInterval(key_repeat_interval);
+
+        // Repeat after a delay as long as pressed
+        if (!no_repeat[keysym])
+          key_repeat_timeout = window.setTimeout(function () {
+            key_repeat_interval = window.setInterval(function () {
+              guac_keyboard.onkeyup(keysym);
+              guac_keyboard.onkeydown(keysym);
+            }, 50);
+          }, 500);
+
+        return result;
+      }
+    }
+
+    // Return the last keydown result by default, resort to false if unknown
+    return last_keydown_result[keysym] || false;
+  };
+
+  /**
+   * Marks a key as released, firing the keyup event if registered.
+   *
+   * @param {Number} keysym The keysym of the key to release.
+   */
+  this.release = function (keysym) {
+    // Only release if pressed
+    if (guac_keyboard.pressed[keysym]) {
+      // Mark key as released
+      delete guac_keyboard.pressed[keysym];
+      delete implicitlyPressed[keysym];
+
+      // Stop repeat
+      window.clearTimeout(key_repeat_timeout);
+      window.clearInterval(key_repeat_interval);
+
+      // Send key event
+      if (keysym !== null && guac_keyboard.onkeyup)
+        guac_keyboard.onkeyup(keysym);
+    }
+  };
+
+  /**
+   * Presses and releases the keys necessary to type the given string of
+   * text.
+   *
+   * @param {String} str
+   *     The string to type.
+   */
+  this.type = function type(str) {
+    // Press/release the key corresponding to each character in the string
+    for (var i = 0; i < str.length; i++) {
+      // Determine keysym of current character
+      var codepoint = str.codePointAt ? str.codePointAt(i) : str.charCodeAt(i);
+      var keysym = keysym_from_charcode(codepoint);
+
+      // Press and release key for current character
+      guac_keyboard.press(keysym);
+      guac_keyboard.release(keysym);
+    }
+  };
+
+  /**
+   * Resets the state of this keyboard, releasing all keys, and firing keyup
+   * events for each released key.
+   */
+  this.reset = function () {
+    // Release all pressed keys
+    for (var keysym in guac_keyboard.pressed)
+      guac_keyboard.release(parseInt(keysym));
+
+    // Clear event log
+    eventLog = [];
+  };
+
+  /**
+   * Given the remote and local state of a particular key, resynchronizes the
+   * remote state of that key with the local state through pressing or
+   * releasing keysyms.
+   *
+   * @private
+   * @param {Boolean} remoteState
+   *     Whether the key is currently pressed remotely.
+   *
+   * @param {Boolean} localState
+   *     Whether the key is currently pressed remotely locally. If the state
+   *     of the key is not known, this may be undefined.
+   *
+   * @param {Number[]} keysyms
+   *     The keysyms which represent the key being updated.
+   *
+   * @param {KeyEvent} keyEvent
+   *     Guacamole's current best interpretation of the key event being
+   *     processed.
+   */
+  var updateModifierState = function updateModifierState(
+    remoteState,
+    localState,
+    keysyms,
+    keyEvent
+  ) {
+    var i;
+
+    // Do not trust changes in modifier state for events directly involving
+    // that modifier: (1) the flag may erroneously be cleared despite
+    // another version of the same key still being held and (2) the change
+    // in flag may be due to the current event being processed, thus
+    // updating things here is at best redundant and at worst incorrect
+    if (keysyms.indexOf(keyEvent.keysym) !== -1) return;
+
+    // Release all related keys if modifier is implicitly released
+    if (remoteState && localState === false) {
+      for (i = 0; i < keysyms.length; i++) {
+        guac_keyboard.release(keysyms[i]);
+      }
+    }
+
+    // Press if modifier is implicitly pressed
+    else if (!remoteState && localState) {
+      // Verify that modifier flag isn't already pressed or already set
+      // due to another version of the same key being held down
+      for (i = 0; i < keysyms.length; i++) {
+        if (guac_keyboard.pressed[keysyms[i]]) return;
+      }
+
+      // Mark as implicitly pressed only if there is other information
+      // within the key event relating to a different key. Some
+      // platforms, such as iOS, will send essentially empty key events
+      // for modifier keys, using only the modifier flags to signal the
+      // identity of the key.
+      var keysym = keysyms[0];
+      if (keyEvent.keysym) implicitlyPressed[keysym] = true;
+
+      guac_keyboard.press(keysym);
+    }
+  };
+
+  /**
+   * Given a keyboard event, updates the local modifier state and remote
+   * key state based on the modifier flags within the event. This function
+   * pays no attention to keycodes.
+   *
+   * @private
+   * @param {KeyboardEvent} e
+   *     The keyboard event containing the flags to update.
+   *
+   * @param {KeyEvent} keyEvent
+   *     Guacamole's current best interpretation of the key event being
+   *     processed.
+   */
+  var syncModifierStates = function syncModifierStates(e, keyEvent) {
+    // Get state
+    var state = Guacamole.Keyboard.ModifierState.fromKeyboardEvent(e);
+
+    // Resync state of alt
+    updateModifierState(
+      guac_keyboard.modifiers.alt,
+      state.alt,
+      [
+        0xffe9, // Left alt
+        0xffea, // Right alt
+        0xfe03, // AltGr
+      ],
+      keyEvent
+    );
+
+    // Resync state of shift
+    updateModifierState(
+      guac_keyboard.modifiers.shift,
+      state.shift,
+      [
+        0xffe1, // Left shift
+        0xffe2, // Right shift
+      ],
+      keyEvent
+    );
+
+    // Resync state of ctrl
+    updateModifierState(
+      guac_keyboard.modifiers.ctrl,
+      state.ctrl,
+      [
+        0xffe3, // Left ctrl
+        0xffe4, // Right ctrl
+      ],
+      keyEvent
+    );
+
+    // Resync state of meta
+    updateModifierState(
+      guac_keyboard.modifiers.meta,
+      state.meta,
+      [
+        0xffe7, // Left meta
+        0xffe8, // Right meta
+      ],
+      keyEvent
+    );
+
+    // Resync state of hyper
+    updateModifierState(
+      guac_keyboard.modifiers.hyper,
+      state.hyper,
+      [
+        0xffeb, // Left hyper
+        0xffec, // Right hyper
+      ],
+      keyEvent
+    );
+
+    // Update state
+    guac_keyboard.modifiers = state;
+  };
+
+  /**
+   * Returns whether all currently pressed keys were implicitly pressed. A
+   * key is implicitly pressed if its status was inferred indirectly from
+   * inspection of other key events.
+   *
+   * @private
+   * @returns {Boolean}
+   *     true if all currently pressed keys were implicitly pressed, false
+   *     otherwise.
+   */
+  var isStateImplicit = function isStateImplicit() {
+    for (var keysym in guac_keyboard.pressed) {
+      if (!implicitlyPressed[keysym]) return false;
+    }
+
+    return true;
+  };
+
+  /**
+   * Reads through the event log, removing events from the head of the log
+   * when the corresponding true key presses are known (or as known as they
+   * can be).
+   *
+   * @private
+   * @return {Boolean} Whether the default action of the latest event should
+   *                   be prevented.
+   */
+  function interpret_events() {
+    // Do not prevent default if no event could be interpreted
+    var handled_event = interpret_event();
+    if (!handled_event) return false;
+
+    // Interpret as much as possible
+    var last_event;
+    do {
+      last_event = handled_event;
+      handled_event = interpret_event();
+    } while (handled_event !== null);
+
+    // Reset keyboard state if we cannot expect to receive any further
+    // keyup events
+    if (isStateImplicit()) guac_keyboard.reset();
+
+    return last_event.defaultPrevented;
+  }
+
+  /**
+   * Releases Ctrl+Alt, if both are currently pressed and the given keysym
+   * looks like a key that may require AltGr.
+   *
+   * @private
+   * @param {Number} keysym The key that was just pressed.
+   */
+  var release_simulated_altgr = function release_simulated_altgr(keysym) {
+    // Both Ctrl+Alt must be pressed if simulated AltGr is in use
+    if (!guac_keyboard.modifiers.ctrl || !guac_keyboard.modifiers.alt) return;
+
+    // Assume [A-Z] never require AltGr
+    if (keysym >= 0x0041 && keysym <= 0x005a) return;
+
+    // Assume [a-z] never require AltGr
+    if (keysym >= 0x0061 && keysym <= 0x007a) return;
+
+    // Release Ctrl+Alt if the keysym is printable
+    if (keysym <= 0xff || (keysym & 0xff000000) === 0x01000000) {
+      guac_keyboard.release(0xffe3); // Left ctrl
+      guac_keyboard.release(0xffe4); // Right ctrl
+      guac_keyboard.release(0xffe9); // Left alt
+      guac_keyboard.release(0xffea); // Right alt
+    }
+  };
+
+  /**
+   * Reads through the event log, interpreting the first event, if possible,
+   * and returning that event. If no events can be interpreted, due to a
+   * total lack of events or the need for more events, null is returned. Any
+   * interpreted events are automatically removed from the log.
+   *
+   * @private
+   * @return {KeyEvent}
+   *     The first key event in the log, if it can be interpreted, or null
+   *     otherwise.
+   */
+  var interpret_event = function interpret_event() {
+    // Peek at first event in log
+    var first = eventLog[0];
+    if (!first) return null;
+
+    // Keydown event
+    if (first instanceof KeydownEvent) {
+      var keysym = null;
+      var accepted_events = [];
+
+      // If event itself is reliable, no need to wait for other events
+      if (first.reliable) {
+        keysym = first.keysym;
+        accepted_events = eventLog.splice(0, 1);
+      }
+
+      // If keydown is immediately followed by a keypress, use the indicated character
+      else if (eventLog[1] instanceof KeypressEvent) {
+        keysym = eventLog[1].keysym;
+        accepted_events = eventLog.splice(0, 2);
+      }
+
+      // If keydown is immediately followed by anything else, then no
+      // keypress can possibly occur to clarify this event, and we must
+      // handle it now
+      else if (eventLog[1]) {
+        keysym = first.keysym;
+        accepted_events = eventLog.splice(0, 1);
+      }
+
+      // Fire a key press if valid events were found
+      if (accepted_events.length > 0) {
+        if (keysym) {
+          // Fire event
+          release_simulated_altgr(keysym);
+          var defaultPrevented = !guac_keyboard.press(keysym);
+          recentKeysym[first.keyCode] = keysym;
+
+          // Release the key now if we cannot rely on the associated
+          // keyup event
+          if (!first.keyupReliable) guac_keyboard.release(keysym);
+
+          // Record whether default was prevented
+          for (var i = 0; i < accepted_events.length; i++)
+            accepted_events[i].defaultPrevented = defaultPrevented;
+        }
+
+        return first;
+      }
+    } // end if keydown
+
+    // Keyup event
+    else if (first instanceof KeyupEvent && !quirks.keyupUnreliable) {
+      // Release specific key if known
+      var keysym = first.keysym;
+      if (keysym) {
+        guac_keyboard.release(keysym);
+        delete recentKeysym[first.keyCode];
+        first.defaultPrevented = true;
+      }
+
+      // Otherwise, fall back to releasing all keys
+      else {
+        guac_keyboard.reset();
+        return first;
+      }
+
+      return eventLog.shift();
+    } // end if keyup
+
+    // Ignore any other type of event (keypress by itself is invalid, and
+    // unreliable keyup events should simply be dumped)
+    else return eventLog.shift();
+
+    // No event interpreted
+    return null;
+  };
+
+  /**
+   * Returns the keyboard location of the key associated with the given
+   * keyboard event. The location differentiates key events which otherwise
+   * have the same keycode, such as left shift vs. right shift.
+   *
+   * @private
+   * @param {KeyboardEvent} e
+   *     A JavaScript keyboard event, as received through the DOM via a
+   *     "keydown", "keyup", or "keypress" handler.
+   *
+   * @returns {Number}
+   *     The location of the key event on the keyboard, as defined at:
+   *     http://www.w3.org/TR/DOM-Level-3-Events/#events-KeyboardEvent
+   */
+  var getEventLocation = function getEventLocation(e) {
+    // Use standard location, if possible
+    if ('location' in e) return e.location;
+
+    // Failing that, attempt to use deprecated keyLocation
+    if ('keyLocation' in e) return e.keyLocation;
+
+    // If no location is available, assume left side
+    return 0;
+  };
+
+  /**
+   * Attempts to mark the given Event as having been handled by this
+   * Guacamole.Keyboard. If the Event has already been marked as handled,
+   * false is returned.
+   *
+   * @param {Event} e
+   *     The Event to mark.
+   *
+   * @returns {Boolean}
+   *     true if the given Event was successfully marked, false if the given
+   *     Event was already marked.
+   */
+  var markEvent = function markEvent(e) {
+    // Fail if event is already marked
+    if (e[EVENT_MARKER]) return false;
+
+    // Mark event otherwise
+    e[EVENT_MARKER] = true;
+    return true;
+  };
+
+  /**
+   * Attaches event listeners to the given Element, automatically translating
+   * received key, input, and composition events into simple keydown/keyup
+   * events signalled through this Guacamole.Keyboard's onkeydown and
+   * onkeyup handlers.
+   *
+   * @param {Element|Document} element
+   *     The Element to attach event listeners to for the sake of handling
+   *     key or input events.
+   */
+  this.listenTo = function listenTo(element) {
+    // When key pressed
+    element.addEventListener(
+      'keydown',
+      function (e) {
+        // Only intercept if handler set
+        if (!guac_keyboard.onkeydown) return;
+
+        // Ignore events which have already been handled
+        if (!markEvent(e)) return;
+
+        var keyCode;
+        if (window.event) keyCode = window.event.keyCode;
+        else if (e.which) keyCode = e.which;
+
+        // Fix modifier states
+        var keydownEvent = new KeydownEvent(
+          keyCode,
+          e.keyIdentifier,
+          e.key,
+          getEventLocation(e)
+        );
+        syncModifierStates(e, keydownEvent);
+
+        // Ignore (but do not prevent) the "composition" keycode sent by some
+        // browsers when an IME is in use (see: http://lists.w3.org/Archives/Public/www-dom/2010JulSep/att-0182/keyCode-spec.html)
+        if (keyCode === 229) return;
+
+        // Log event
+        eventLog.push(keydownEvent);
+
+        // Interpret as many events as possible, prevent default if indicated
+        if (interpret_events()) e.preventDefault();
+      },
+      true
+    );
+
+    // When key pressed
+    element.addEventListener(
+      'keypress',
+      function (e) {
+        // Only intercept if handler set
+        if (!guac_keyboard.onkeydown && !guac_keyboard.onkeyup) return;
+
+        // Ignore events which have already been handled
+        if (!markEvent(e)) return;
+
+        var charCode;
+        if (window.event) charCode = window.event.keyCode;
+        else if (e.which) charCode = e.which;
+
+        // Fix modifier states
+        var keypressEvent = new KeypressEvent(charCode);
+        syncModifierStates(e, keypressEvent);
+
+        // Log event
+        eventLog.push(keypressEvent);
+
+        // Interpret as many events as possible, prevent default if indicated
+        if (interpret_events()) e.preventDefault();
+      },
+      true
+    );
+
+    // When key released
+    element.addEventListener(
+      'keyup',
+      function (e) {
+        // Only intercept if handler set
+        if (!guac_keyboard.onkeyup) return;
+
+        // Ignore events which have already been handled
+        if (!markEvent(e)) return;
+
+        e.preventDefault();
+
+        var keyCode;
+        if (window.event) keyCode = window.event.keyCode;
+        else if (e.which) keyCode = e.which;
+
+        // Fix modifier states
+        var keyupEvent = new KeyupEvent(
+          keyCode,
+          e.keyIdentifier,
+          e.key,
+          getEventLocation(e)
+        );
+        syncModifierStates(e, keyupEvent);
+
+        // Log event, call for interpretation
+        eventLog.push(keyupEvent);
+        interpret_events();
+      },
+      true
+    );
+
+    /**
+     * Handles the given "input" event, typing the data within the input text.
+     * If the event is complete (text is provided), handling of "compositionend"
+     * events is suspended, as such events may conflict with input events.
+     *
+     * @private
+     * @param {InputEvent} e
+     *     The "input" event to handle.
+     */
+    var handleInput = function handleInput(e) {
+      // Only intercept if handler set
+      if (!guac_keyboard.onkeydown && !guac_keyboard.onkeyup) return;
+
+      // Ignore events which have already been handled
+      if (!markEvent(e)) return;
+
+      // Type all content written
+      if (e.data && !e.isComposing) {
+        element.removeEventListener('compositionend', handleComposition, false);
+        guac_keyboard.type(e.data);
+      }
+    };
+
+    /**
+     * Handles the given "compositionend" event, typing the data within the
+     * composed text. If the event is complete (composed text is provided),
+     * handling of "input" events is suspended, as such events may conflict
+     * with composition events.
+     *
+     * @private
+     * @param {CompositionEvent} e
+     *     The "compositionend" event to handle.
+     */
+    var handleComposition = function handleComposition(e) {
+      // Only intercept if handler set
+      if (!guac_keyboard.onkeydown && !guac_keyboard.onkeyup) return;
+
+      // Ignore events which have already been handled
+      if (!markEvent(e)) return;
+
+      // Type all content written
+      if (e.data) {
+        element.removeEventListener('input', handleInput, false);
+        guac_keyboard.type(e.data);
+      }
+    };
+
+    // Automatically type text entered into the wrapped field
+    element.addEventListener('input', handleInput, false);
+    element.addEventListener('compositionend', handleComposition, false);
+  };
+
+  // Listen to given element, if any
+  if (element) guac_keyboard.listenTo(element);
+};
+
+/**
+ * The unique numerical identifier to assign to the next Guacamole.Keyboard
+ * instance.
+ *
+ * @private
+ * @type {Number}
+ */
+Guacamole.Keyboard._nextID = 0;
+
+/**
+ * The state of all supported keyboard modifiers.
+ * @constructor
+ */
+Guacamole.Keyboard.ModifierState = function () {
+  /**
+   * Whether shift is currently pressed.
+   * @type {Boolean}
+   */
+  this.shift = false;
+
+  /**
+   * Whether ctrl is currently pressed.
+   * @type {Boolean}
+   */
+  this.ctrl = false;
+
+  /**
+   * Whether alt is currently pressed.
+   * @type {Boolean}
+   */
+  this.alt = false;
+
+  /**
+   * Whether meta (apple key) is currently pressed.
+   * @type {Boolean}
+   */
+  this.meta = false;
+
+  /**
+   * Whether hyper (windows key) is currently pressed.
+   * @type {Boolean}
+   */
+  this.hyper = false;
+};
+
+/**
+ * Returns the modifier state applicable to the keyboard event given.
+ *
+ * @param {KeyboardEvent} e The keyboard event to read.
+ * @returns {Guacamole.Keyboard.ModifierState} The current state of keyboard
+ *                                             modifiers.
+ */
+Guacamole.Keyboard.ModifierState.fromKeyboardEvent = function (e) {
+  var state = new Guacamole.Keyboard.ModifierState();
+
+  // Assign states from old flags
+  state.shift = e.shiftKey;
+  state.ctrl = e.ctrlKey;
+  state.alt = e.altKey;
+  state.meta = e.metaKey;
+
+  // Use DOM3 getModifierState() for others
+  if (e.getModifierState) {
+    state.hyper =
+      e.getModifierState('OS') ||
+      e.getModifierState('Super') ||
+      e.getModifierState('Hyper') ||
+      e.getModifierState('Win');
+  }
+
+  return state;
+};
+
+export default Guacamole.Keyboard;

--- a/src/components/VBrowser/index.ts
+++ b/src/components/VBrowser/index.ts
@@ -7,9 +7,9 @@ import {
   ControlClipboardPayload,
   ControlPayload,
   ControlTargetPayload,
-  DisconnectPayload,
   ScreenConfigurationsPayload,
   ScreenResolutionPayload,
+  SystemMessagePayload,
 } from './messages';
 
 export class NekoClient extends BaseClient implements EventEmitter<any> {
@@ -24,6 +24,7 @@ export class NekoClient extends BaseClient implements EventEmitter<any> {
   /////////////////////////////
   // Internal Events
   /////////////////////////////
+  protected [EVENT.RECONNECTING]() {}
   protected [EVENT.CONNECTING]() {}
 
   protected [EVENT.CONNECTED]() {
@@ -47,7 +48,7 @@ export class NekoClient extends BaseClient implements EventEmitter<any> {
   /////////////////////////////
   // System Events
   /////////////////////////////
-  protected [EVENT.SYSTEM.DISCONNECT]({ message }: DisconnectPayload) {
+  protected [EVENT.SYSTEM.DISCONNECT]({ message }: SystemMessagePayload) {
     this.onDisconnected(new Error(message));
   }
 

--- a/src/components/VBrowser/keyboard.ts
+++ b/src/components/VBrowser/keyboard.ts
@@ -67,11 +67,12 @@ export interface GuacamoleKeyboardInterface {
   listenTo: (element: Element | Document) => void;
 }
 
-//@ts-ignore
-export default function (element?: Element): GuacamoleKeyboardInterface {
+const Interface = function (element?: Element): GuacamoleKeyboardInterface {
   const Keyboard = {};
 
   GuacamoleKeyboard.bind(Keyboard, element)();
 
   return Keyboard as GuacamoleKeyboardInterface;
-}
+};
+
+export default Interface;

--- a/src/components/VBrowser/keyboard.ts
+++ b/src/components/VBrowser/keyboard.ts
@@ -67,6 +67,7 @@ export interface GuacamoleKeyboardInterface {
   listenTo: (element: Element | Document) => void;
 }
 
+//@ts-ignore
 export default function (element?: Element): GuacamoleKeyboardInterface {
   const Keyboard = {};
 

--- a/src/components/VBrowser/keyboard.ts
+++ b/src/components/VBrowser/keyboard.ts
@@ -1,0 +1,76 @@
+import GuacamoleKeyboard from './guacamole-keyboard';
+
+export interface GuacamoleKeyboardInterface {
+  /**
+   * Fired whenever the user presses a key with the element associated
+   * with this Guacamole.Keyboard in focus.
+   *
+   * @event
+   * @param {Number} keysym The keysym of the key being pressed.
+   * @return {Boolean} true if the key event should be allowed through to the
+   *                   browser, false otherwise.
+   */
+  onkeydown?: (keysym: number) => boolean;
+
+  /**
+   * Fired whenever the user releases a key with the element associated
+   * with this Guacamole.Keyboard in focus.
+   *
+   * @event
+   * @param {Number} keysym The keysym of the key being released.
+   */
+  onkeyup?: (keysym: number) => void;
+
+  /**
+   * Marks a key as pressed, firing the keydown event if registered. Key
+   * repeat for the pressed key will start after a delay if that key is
+   * not a modifier. The return value of this function depends on the
+   * return value of the keydown event handler, if any.
+   *
+   * @param {Number} keysym The keysym of the key to press.
+   * @return {Boolean} true if event should NOT be canceled, false otherwise.
+   */
+  press: (keysym: number) => boolean;
+
+  /**
+   * Marks a key as released, firing the keyup event if registered.
+   *
+   * @param {Number} keysym The keysym of the key to release.
+   */
+  release: (keysym: number) => void;
+
+  /**
+   * Presses and releases the keys necessary to type the given string of
+   * text.
+   *
+   * @param {String} str
+   *     The string to type.
+   */
+  type: (str: string) => void;
+
+  /**
+   * Resets the state of this keyboard, releasing all keys, and firing keyup
+   * events for each released key.
+   */
+  reset: () => void;
+
+  /**
+   * Attaches event listeners to the given Element, automatically translating
+   * received key, input, and composition events into simple keydown/keyup
+   * events signalled through this Guacamole.Keyboard's onkeydown and
+   * onkeyup handlers.
+   *
+   * @param {Element|Document} element
+   *     The Element to attach event listeners to for the sake of handling
+   *     key or input events.
+   */
+  listenTo: (element: Element | Document) => void;
+}
+
+export default function (element?: Element): GuacamoleKeyboardInterface {
+  const Keyboard = {};
+
+  GuacamoleKeyboard.bind(Keyboard, element)();
+
+  return Keyboard as GuacamoleKeyboardInterface;
+}

--- a/src/components/VBrowser/messages.d.ts
+++ b/src/components/VBrowser/messages.d.ts
@@ -14,7 +14,9 @@ import { Member, ScreenConfigurations, ScreenResolution } from './types';
 export type WebSocketMessages =
   | WebSocketMessage
   | SignalProvideMessage
+  | SignalOfferMessage
   | SignalAnswerMessage
+  | SignalCandidateMessage
   | MemberListMessage
   | MemberConnectMessage
   | MemberDisconnectMessage
@@ -25,17 +27,23 @@ export type WebSocketMessages =
 
 export type WebSocketPayloads =
   | SignalProvidePayload
+  | SignalOfferPayload
   | SignalAnswerPayload
+  | SignalCandidatePayload
   | MemberListPayload
   | Member
   | ControlPayload
   | ControlClipboardPayload
+  | ControlKeyboardPayload
   | ChatPayload
   | ChatSendPayload
   | EmojiSendPayload
   | ScreenResolutionPayload
   | ScreenConfigurationsPayload
-  | AdminPayload;
+  | AdminPayload
+  | AdminLockPayload
+  | BroadcastStatusPayload
+  | BroadcastCreatePayload;
 
 export interface WebSocketMessage {
   event: WebSocketEvents | string;
@@ -44,11 +52,22 @@ export interface WebSocketMessage {
 /*
   SYSTEM MESSAGES/PAYLOADS
 */
-// system/disconnect
-export interface DisconnectMessage extends WebSocketMessage, DisconnectPayload {
-  event: typeof EVENT.SYSTEM.DISCONNECT;
+// system/init
+export interface SystemInit extends WebSocketMessage, SystemInitPayload {
+  event: typeof EVENT.SYSTEM.INIT;
 }
-export interface DisconnectPayload {
+export interface SystemInitPayload {
+  implicit_hosting: boolean;
+  locks: Record<string, string>;
+}
+
+// system/disconnect
+// system/error
+export interface SystemMessage extends WebSocketMessage, SystemMessagePayload {
+  event: typeof EVENT.SYSTEM.DISCONNECT | typeof EVENT.SYSTEM.ERROR;
+}
+export interface SystemMessagePayload {
+  title: string;
   message: string;
 }
 
@@ -64,7 +83,17 @@ export interface SignalProvideMessage
 export interface SignalProvidePayload {
   id: string;
   lite: boolean;
-  ice: string[];
+  ice: RTCIceServer[];
+  sdp: string;
+}
+
+// signal/offer
+export interface SignalOfferMessage
+  extends WebSocketMessage,
+    SignalOfferPayload {
+  event: typeof EVENT.SIGNAL.OFFER;
+}
+export interface SignalOfferPayload {
   sdp: string;
 }
 
@@ -77,6 +106,16 @@ export interface SignalAnswerMessage
 export interface SignalAnswerPayload {
   sdp: string;
   displayname: string;
+}
+
+// signal/candidate
+export interface SignalCandidateMessage
+  extends WebSocketMessage,
+    SignalCandidatePayload {
+  event: typeof EVENT.SIGNAL.CANDIDATE;
+}
+export interface SignalCandidatePayload {
+  data: string;
 }
 
 /*
@@ -124,6 +163,13 @@ export interface ControlTargetPayload {
 
 export interface ControlClipboardPayload {
   text: string;
+}
+
+export interface ControlKeyboardPayload {
+  layout?: string;
+  capsLock?: boolean;
+  numLock?: boolean;
+  scrollLock?: boolean;
 }
 
 /*
@@ -180,6 +226,18 @@ export interface ScreenConfigurationsPayload {
 }
 
 /*
+  BROADCAST PAYLOADS
+*/
+export interface BroadcastCreatePayload {
+  url: string;
+}
+
+export interface BroadcastStatusPayload {
+  url: string;
+  isActive: boolean;
+}
+
+/*
   ADMIN PAYLOADS
 */
 export interface AdminMessage extends WebSocketMessage, AdminPayload {
@@ -199,4 +257,15 @@ export interface AdminTargetMessage
 export interface AdminTargetPayload {
   id: string;
   target?: string;
+}
+
+export interface AdminLockMessage extends WebSocketMessage, AdminLockPayload {
+  event: AdminEvents;
+  id: string;
+}
+
+export type AdminLockResource = 'login' | 'control';
+
+export interface AdminLockPayload {
+  resource: AdminLockResource;
 }


### PR DESCRIPTION
fixes #65 
fixes #402 

Updated the vbrowser to the maintained fork of neko which features Guacamole keyboard support.

There are some backward incompatible keyboard changes so users may need to restart their vbrowsers to maintain control.

Also made the vbrowser video scale to fit the space at low resolutions.