### PR TITLE
[wip] discord admin bot

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -82,3 +82,10 @@ interface PersistentRoom {
   isSubRoom: boolean;
   data: any;
 }
+
+interface LinkAccount {
+  accountname: string;
+  accountid: string;
+  discriminator: string;
+  kind: string;
+}

--- a/server/config.ts
+++ b/server/config.ts
@@ -49,6 +49,9 @@ const defaults = {
   VM_ASSIGNMENT_TIMEOUT: 75, // Number of seconds to wait for a VM before failing
   DEFAULT_VM_REGION: 'US', // The default region to use for free VM/pool selection
   DISCORD_BOT_TOKEN: '', // Token for the Discord bot that generates WatchParty links
+  DISCORD_ADMIN_BOT_TOKEN: '', // Optional, for Discord bot to set subscriber roles
+  DISCORD_ADMIN_BOT_SERVER_ID: '', // Optional, ID of the Discord server
+  DISCORD_ADMIN_BOT_SUB_ROLE_ID: '', // Optional, ID of subscriber role
 };
 
 export default {

--- a/server/config.ts
+++ b/server/config.ts
@@ -50,8 +50,8 @@ const defaults = {
   DEFAULT_VM_REGION: 'US', // The default region to use for free VM/pool selection
   DISCORD_BOT_TOKEN: '', // Token for the Discord bot that generates WatchParty links
   DISCORD_ADMIN_BOT_TOKEN: '', // Optional, for Discord bot to set subscriber roles
-  DISCORD_ADMIN_BOT_SERVER_ID: '', // Optional, ID of the Discord server
-  DISCORD_ADMIN_BOT_SUB_ROLE_ID: '', // Optional, ID of subscriber role
+  DISCORD_ADMIN_BOT_SERVER_ID: '708181150220156929', // Optional, ID of the Discord server
+  DISCORD_ADMIN_BOT_SUB_ROLE_ID: '722202622345609246', // Optional, ID of subscriber role
 };
 
 export default {

--- a/server/syncSubs.ts
+++ b/server/syncSubs.ts
@@ -13,6 +13,8 @@ const postgres2 = new Client({
 });
 postgres2.connect();
 
+// TODO set up the Discord admin bot
+
 setInterval(syncSubscribers, 60 * 1000);
 
 async function syncSubscribers() {
@@ -110,5 +112,21 @@ async function syncSubscribers() {
       await postgres2?.query('ROLLBACK');
     }
   }
+
+  // TODO Update the sub status of users in Discord
+  // const guild = this.guilds.cache.get(config.DISCORD_SERVER_ID);
+  // const role = guild?.roles.cache.get(config.DISCORD_SUB_ROLE_ID);
+  // const members = await guild?.members.fetch();
+  // const user = members?.find(
+  //   (member) =>
+  //     member.user.username === username &&
+  //     member.user.discriminator === discriminator
+  // );
+  // if (undo) {
+  //   return await user?.roles.remove(role as Role);
+  // } else {
+  //   return await user?.roles.add(role as Role);
+  // }
+
   console.timeEnd('syncSubscribers');
 }

--- a/server/utils/moniker.ts
+++ b/server/utils/moniker.ts
@@ -13,7 +13,7 @@ const verbs = fs
   .readFileSync(process.env.PWD + '/verbs.txt')
   .toString()
   .split('\n');
-const randomElement = (array: Array<string>) =>
+const randomElement = (array: string[]) =>
   array[Math.floor(Math.random() * array.length)];
 
 export function makeName(shard: number | undefined) {

--- a/server/utils/postgres.ts
+++ b/server/utils/postgres.ts
@@ -47,7 +47,9 @@ export async function upsertObject(
   const values = Object.values(object);
   let query = `INSERT INTO ${table} (${columns.map((c) => `"${c}"`).join(',')})
     VALUES (${values.map((_, i) => '$' + (i + 1)).join(',')})
-    ON CONFLICT ("${Object.keys(conflict).join(',')}")
+    ON CONFLICT (${Object.keys(conflict)
+      .map((k) => `"${k}"`)
+      .join(',')})
     DO UPDATE SET ${Object.keys(object)
       .map((c) => `"${c}" = EXCLUDED."${c}"`)
       .join(',')}

--- a/server/vm/utils.ts
+++ b/server/vm/utils.ts
@@ -106,7 +106,7 @@ function createVMManager(poolConfig: PoolConfig): VMManager | null {
   return vmManager;
 }
 
-export function getVMManagerConfig(): Array<PoolConfig> {
+export function getVMManagerConfig(): PoolConfig[] {
   return config.VM_MANAGER_CONFIG.split(',').map((c) => {
     const split = c.split(':');
     return {

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -25,12 +25,13 @@ CREATE TABLE subscriber(
   PRIMARY KEY(uid)
 );
 
-CREATE TABLE account(
-  email text,
-  id string,
-  username string,
-  discriminator string,
-  PRIMARY KEY(email)
+CREATE TABLE link_account(
+  uid text,
+  kind text,
+  accountid text,
+  accountname text,
+  discriminator text,
+  PRIMARY KEY(uid, kind)
 );
 
 CREATE UNIQUE INDEX on room (LOWER(vanity)) WHERE vanity IS NOT NULL;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -25,6 +25,14 @@ CREATE TABLE subscriber(
   PRIMARY KEY(uid)
 );
 
+CREATE TABLE account(
+  email text,
+  id string,
+  username string,
+  discriminator string,
+  PRIMARY KEY(email)
+);
+
 CREATE UNIQUE INDEX on room (LOWER(vanity)) WHERE vanity IS NOT NULL;
 CREATE INDEX on room(owner) WHERE owner IS NOT NULL;
 CREATE INDEX on room("creationTime");

--- a/src/components/Discord/Discord.tsx
+++ b/src/components/Discord/Discord.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import firebase from 'firebase/compat/app';
+import { serverPath } from '../../utils';
+
+type DiscordProps = {
+  user?: firebase.User;
+};
+
+export const Discord = ({ user }: DiscordProps) => {
+  const [errorMsg, setErrorMsg] = useState('');
+
+  useEffect(() => {
+    async function auth() {
+      const fragment = new URLSearchParams(window.location.hash.slice(1));
+      const [accessToken, tokenType] = [
+        fragment.get('access_token'),
+        fragment.get('token_type'),
+      ];
+      const result = await fetch('https://discord.com/api/users/@me', {
+        headers: {
+          authorization: `${tokenType} ${accessToken}`,
+        },
+      });
+      const response = await result.json();
+      const { username, discriminator } = response;
+
+      const token = await user?.getIdToken();
+      const authResponse = await window.fetch(serverPath + '/discord/auth', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          uid: user?.uid,
+          token,
+          username,
+          discriminator,
+        }),
+      });
+      if (authResponse.status !== 200) {
+        const body = await authResponse.json();
+        setErrorMsg(body.error);
+      } else {
+        window.opener.location.reload(false);
+        window.close();
+      }
+    }
+    if (user) {
+      auth();
+    }
+  }, [user]);
+
+  if (errorMsg) {
+    return <div style={{ color: 'red', fontSize: 20 }}>{errorMsg}</div>;
+  }
+  return null;
+};

--- a/src/components/Discord/Discord.tsx
+++ b/src/components/Discord/Discord.tsx
@@ -9,6 +9,7 @@ type DiscordProps = {
 export const Discord = ({ user }: DiscordProps) => {
   const [errorMsg, setErrorMsg] = useState('');
 
+  console.log(user);
   useEffect(() => {
     async function auth() {
       const fragment = new URLSearchParams(window.location.hash.slice(1));
@@ -16,25 +17,18 @@ export const Discord = ({ user }: DiscordProps) => {
         fragment.get('access_token'),
         fragment.get('token_type'),
       ];
-      const result = await fetch('https://discord.com/api/users/@me', {
-        headers: {
-          authorization: `${tokenType} ${accessToken}`,
-        },
-      });
-      const response = await result.json();
-      const { username, discriminator } = response;
-
       const token = await user?.getIdToken();
-      const authResponse = await window.fetch(serverPath + '/discord/auth', {
+      const authResponse = await window.fetch(serverPath + '/linkAccount', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
           uid: user?.uid,
-          token,
-          username,
-          discriminator,
+          kind: 'discord',
+          token: token,
+          tokenType,
+          accessToken,
         }),
       });
       if (authResponse.status !== 200) {

--- a/src/components/Modal/ProfileModal.tsx
+++ b/src/components/Modal/ProfileModal.tsx
@@ -58,6 +58,30 @@ export class ProfileModal extends React.Component<{
     window.location.reload();
   };
 
+  authDiscord = () => {
+    const url = process.env.REACT_APP_DISCORD_AUTH_URL;
+    window.open(
+      url,
+      '_blank',
+      'toolbar=0,location=0,menubar=0,width=450,height=900'
+    );
+  };
+
+  deleteDiscord = async () => {
+    const token = await this.props.user.getIdToken();
+    await window.fetch(serverPath + '/discord/delete', {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        uid: this.props.user.uid,
+        token,
+      }),
+    });
+    window.location.reload();
+  };
+
   render() {
     const { close, userImage } = this.props;
     return (
@@ -140,6 +164,43 @@ export class ProfileModal extends React.Component<{
               <Icon name="check circle" />
               Verify Email
             </Button>
+            {this.props.discordUsername && this.props.discordDiscriminator ? (
+              <Button
+                icon
+                labelPosition="left"
+                fluid
+                color="red"
+                animated="fade"
+                onClick={this.deleteDiscord}
+              >
+                <Icon name="discord" />
+                <Button.Content visible>Unlink Discord Account</Button.Content>
+                <Button.Content
+                  hidden
+                >{`${this.props.discordUsername}#${this.props.discordDiscriminator}`}</Button.Content>
+              </Button>
+            ) : (
+              <React.Fragment>
+                {process.env.REACT_APP_DISCORD_AUTH_URL && (
+                  <Popup
+                    content="Link your Discord account to get assigned a subscriber role on our Discord server."
+                    trigger={
+                      <Button
+                        icon
+                        labelPosition="left"
+                        fluid
+                        color="orange"
+                        onClick={this.authDiscord}
+                        disabled={!this.props.isSubscriber}
+                      >
+                        <Icon name="discord" />
+                        Get Subscriber Role
+                      </Button>
+                    }
+                  />
+                )}
+              </React.Fragment>
+            )}
             <Button
               disabled={this.state.resetDisabled}
               icon

--- a/src/components/Modal/SubscribeModal.tsx
+++ b/src/components/Modal/SubscribeModal.tsx
@@ -128,7 +128,9 @@ export class SubscribeModal extends React.Component<{
                   </Table.Cell>
                 </Table.Row>
                 <Table.Row>
-                  <Table.Cell>Discord Subscriber Role (on request)</Table.Cell>
+                  <Table.Cell>
+                    Discord Subscriber Role (with linked account)
+                  </Table.Cell>
                   <Table.Cell></Table.Cell>
                   <Table.Cell>
                     <Icon name="check" />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import firebase from 'firebase/compat/app';
 import 'firebase/auth';
 import { serverPath } from './utils';
 import { Create } from './components/Create/Create';
+import { Discord } from './components/Discord/Discord';
 
 const Debug = lazy(() => import('./components/Debug/Debug'));
 
@@ -143,7 +144,9 @@ class WatchParty extends React.Component {
             <DiscordBot />
             <Footer />
           </Route>
-          <Route path="/discord/auth" exact></Route>
+          <Route path="/discord/auth" exact>
+            <Discord user={this.state.user} />
+          </Route>
           <Route path="/debug">
             <TopBar
               user={this.state.user}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -143,6 +143,7 @@ class WatchParty extends React.Component {
             <DiscordBot />
             <Footer />
           </Route>
+          <Route path="/discord/auth" exact></Route>
           <Route path="/debug">
             <TopBar
               user={this.state.user}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -296,7 +296,7 @@ export function getAndSaveClientId() {
   return clientId;
 }
 
-export function calculateMedian(array: Array<number>): number {
+export function calculateMedian(array: number[]): number {
   // Check If Data Exists
   if (array.length >= 1) {
     // Sort Array


### PR DESCRIPTION
fixes #63 

Revisiting #417 with a more generic approach. (thanks @Argn0 for building it originally even though it never shipped)

* Setup to allow linking multiple kinds of accounts
* Just write the linked account data to DB in the main server
* In syncSubs, run the logic to set roles
* Distinguish the admin bot from the public bot (for generating WP links)
* Move validation of the Discord token to the server to avoid users submitting random IDs for sub role