### PR TITLE
Allow .vtt files in subtitle file picker

### DIFF
--- a/src/components/Modal/SubtitleModal.tsx
+++ b/src/components/Modal/SubtitleModal.tsx
@@ -60,7 +60,7 @@ export class SubtitleModal extends React.Component<{
   }
 
   uploadSubtitle = async () => {
-    const files = await openFileSelector(".srt");
+    const files = await openFileSelector(".srt,.vtt");
     if (!files) {
       return;
     }
@@ -129,7 +129,7 @@ export class SubtitleModal extends React.Component<{
               disabled={!this.props.haveLock()}
               leftSection={<IconUpload />}
             >
-              Upload (.srt)
+              Upload (.srt / .vtt)
             </Button>
             <Divider my="lg" />
             <Title order={6}>OpenSubtitles</Title>


### PR DESCRIPTION
This actually already works; if you use "All files" in the file picker, you can upload a .vtt file and it works fine. This change just makes it clear in the UI that you can do that, without having to go through "All files".