### PR TITLE
Handle Windows newlines when reading word lists from disk

### DIFF
--- a/server/utils/moniker.ts
+++ b/server/utils/moniker.ts
@@ -4,15 +4,15 @@ import { resolveShard } from "./resolveShard.ts";
 let adjectives = fs
   .readFileSync(process.cwd() + "/words/adjectives.txt")
   .toString()
-  .split("\n");
+  .split(/\r?\n/);
 const nouns = fs
   .readFileSync(process.cwd() + "/words/nouns.txt")
   .toString()
-  .split("\n");
+  .split(/\r?\n/);
 const verbs = fs
   .readFileSync(process.cwd() + "/words/verbs.txt")
   .toString()
-  .split("\n");
+  .split(/\r?\n/);
 const randomElement = (array: string[]) =>
   array[Math.floor(Math.random() * array.length)];
 


### PR DESCRIPTION
As-is, when developing on Windows, randomly generated room names contain `\r` characters resulting in hard-to-debug bugs. This change fixes that.