### PR TITLE
Allow Encrypted Media Extensions in YouTube iframe

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -2496,7 +2496,7 @@ export class App extends React.Component<AppProps, AppState> {
                       className={styles.videoContent}
                       allowFullScreen
                       frameBorder="0"
-                      allow="autoplay"
+                      allow="autoplay; encrypted-media"
                       src="https://www.youtube.com/embed/?enablejsapi=1&controls=0&rel=0"
                     />
                     {this.playingVBrowser() &&


### PR DESCRIPTION
Without this, DRM-protected YouTube videos (e.g., "YouTube Movies & TV") don't work in Chromium-based browsers, because Permissions Policy doesn't extend by default to cross-origin iframes. See https://www.chromium.org/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes/.